### PR TITLE
Update GetArticle.cs

### DIFF
--- a/net/securing-public-access/GetArticle.cs
+++ b/net/securing-public-access/GetArticle.cs
@@ -6,7 +6,7 @@ using Kentico.Kontent.Delivery;
 IDeliveryClient client = DeliveryClientBuilder
     .WithOptions(builder => builder
         .WithProjectId("<YOUR_PROJECT_ID>")
-        .UseSecuredProductionApi("<YOUR_API_KEY>")
+        .UseProductionApi("<YOUR_API_KEY>")
         .Build())
     .Build();
 


### PR DESCRIPTION
@kentico-michaelb:
In the correct Secured API tutorial docs, the .NET snippet uses .UseSecuredProductionApi("<YOUR_API_KEY>") which is also listed in https://github.com/Kentico/kontent-delivery-sdk-net/wiki/Instantiating-DeliveryClient-with-Configuration-API-and-DI-in-ASP.NET-Core-MVC-apps .  I don't see this option in https://github.com/Kentico/kontent-delivery-sdk-net/blob/master/Kentico.Kontent.Delivery/Configuration/DeliveryOptions.cs though.   Are both locations supposed to use .SecureAccessApiKey("<YOUR_API_KEY>") instead?

@petrsvihlik: the best practice is to use .UseProductionApi("<key>")

![image](https://user-images.githubusercontent.com/9810625/75016608-a6921400-548b-11ea-8233-b9da9d57b0af.png)
