### PR TITLE
CTC-755 Missing JS API Examples

### DIFF
--- a/js/cm-api-v2/DeleteVariant.js
+++ b/js/cm-api-v2/DeleteVariant.js
@@ -1,0 +1,24 @@
+// DocSection: cm_api_v2_delete_variant
+// Tip: Find more about JS/TS SDKs at https://docs.kontent.ai/javascript
+// Using ES6 syntax
+import { ManagementClient } from '@kentico/kontent-management';
+
+const client = new ManagementClient({
+  projectId: '<YOUR_PROJECT_ID>',
+  apiKey: '<YOUR_API_KEY>'
+});
+
+client.deleteLanguageVariant()
+  .byItemId('f4b3fc05-e988-4dae-9ac1-a94aba566474')
+  // .byItemCodename('my_article')
+  // .byItemExternalId('59713')
+  .byLanguageId('d1f95fde-af02-b3b5-bd9e-f232311ccab8')
+  // .byLanguageCodename('es-ES')
+  .toObservable()
+  .subscribe((response) => {
+    console.log(response);
+  },
+    (error) => {
+      console.log(error);
+    });
+// EndDocSection

--- a/js/cm-api-v2/GetTaxonomyGroup.js
+++ b/js/cm-api-v2/GetTaxonomyGroup.js
@@ -1,0 +1,22 @@
+// DocSection: cm_api_v2_get_taxonomy_group
+// Tip: Find more about JS/TS SDKs at https://docs.kontent.ai/javascript
+// Using ES6 syntax
+import { ManagementClient } from '@kentico/kontent-management';
+
+const client = new ManagementClient({
+  projectId: '<YOUR_PROJECT_ID>',
+  apiKey: '<YOUR_API_KEY>'
+});
+
+client.getTaxonomy()
+    .byTaxonomyCodename("personas_222")
+    //.byTaxonomyID("dbff8416-c4c7-45d2-b497-a4a71a5cbe30")
+    //.byTaxonomyExternalID("Tax-Group-124")
+    .toObservable()
+    .subscribe((response) => {
+        console.log(response);
+    },
+    (error) => {
+        console.log(error);
+    });
+// EndDocSection

--- a/js/cm-api-v2/GetVariantsWithComponentsOfType.js
+++ b/js/cm-api-v2/GetVariantsWithComponentsOfType.js
@@ -1,0 +1,21 @@
+// DocSection: cm_api_v2_get_variants_with_components_of_type
+// Tip: Find more about JS/TS SDKs at https://docs.kontent.ai/javascript
+// Using ES6 syntax
+import { ManagementClient } from '@kentico/kontent-management';
+
+const client = new ManagementClient({
+  projectId: '<YOUR_PROJECT_ID>',
+  apiKey: '<YOUR_API_KEY>'
+});
+
+client.listLanguageVariantsOfContentTypeWithComponents()
+  .byTypeCodename('coffee')
+  //.byTypeID('929985ac-4aa5-436b-85a2-94c2d4fbbebd')
+  .toObservable()
+  .subscribe((response) => {
+    console.log(response);
+  },
+    (error) => {
+      console.log(error);
+    });
+// EndDocSection

--- a/js/cm-api-v2/PatchSnippet.js
+++ b/js/cm-api-v2/PatchSnippet.js
@@ -1,0 +1,54 @@
+// DocSection: cm_api_v2_patch_snippet
+// Tip: Find more about JS/TS SDKs at https://docs.kontent.ai/javascript
+// Using ES6 syntax
+import { ManagementClient } from '@kentico/kontent-management';
+
+const client = new ManagementClient({
+  projectId: '<YOUR_PROJECT_ID>',
+  apiKey: '<YOUR_API_KEY>'
+});
+
+client.modifyContentTypeSnippet()
+    .byTypeId('269202ad-1d9d-47\fd-b3e8-bdb05b3e3cf0')
+    //.byTypeCodename('hosted_video')
+    //.byTypeExternalId('snippet-type-123')
+    .withData(
+        [
+            {
+                op: "replace",
+                path: "/name",
+                value: "A new snippet name"
+            },
+            {
+                op: "replace",
+                path: "/elements/codename:my_metadata__my_meta_description/guidelines",
+                value: "Length: 70-150 characters."
+            },
+            {
+                op: "addInto",
+                path: "/elements",
+                value: {
+                    name: "My meta title",
+                    type: "text",
+                    guidelines: "Length: 30–60 characters.",
+                    external_id: "my-meta-title-id"
+                    }
+            },
+            {
+                op: "remove",
+                path: "/elements/id:0b2015d0-16ae-414a-85f9-7e1a4b3a3eae"
+            },
+            {
+                op: "remove",
+                path: "/elements/external_id:my_multiple_choice/options/codename:my_option"
+            }
+        ]
+    )
+    .toObservable()
+    .subscribe((response) => {
+        // work with response
+    },
+    (error) => {
+        // handle error
+    });
+// EndDocSection


### PR DESCRIPTION
4 missing API examples for issue CTC-755:

Delete a Language Variant,
Get a TaxonomyGroup,
Get Language Variants that contain components of a certain type,
Modify a Content Type Snippet

### Motivation

Adds missing code samples for our JS SDK.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
