### PR TITLE
Fix upsert to respect content model

### DIFF
--- a/js/importing-to-kentico-kontent/UpsertLanguageVariant.js
+++ b/js/importing-to-kentico-kontent/UpsertLanguageVariant.js
@@ -36,17 +36,17 @@ client.upsertLanguageVariant()
       },
       value: 'Jihomoravsky kraj'
     }),
-    builder.numberElement({
+    builder.textElement({
       element: {
         codename: 'zip_code'
       },
-      value: 60200
+      value: "60200"
     }),
-    builder.numberElement({
+    builder.textElement({
       element: {
         codename: 'phone'
       },
-      value: 420555555555
+      value: '+420555555555'
     }),
     builder.textElement({
       element: {


### PR DESCRIPTION
### Motivation

Fix upsert to respect content model for Javascript. Also possible to check on REST examples: https://docs.kontent.ai/tutorials/set-up-kontent/import-content/content-items?tech=rest

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Tests are passing
- [ ] Documentation has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
