### PR TITLE
Add update workflow sample to JS MAPIv2

### DIFF
--- a/js/management-api-v2/DeleteWorkflow.js
+++ b/js/management-api-v2/DeleteWorkflow.js
@@ -1,4 +1,4 @@
-// DocSection: cm_api_v2_get_workflow_steps
+// DocSection: cm_api_v2_delete_workflow
 // Tip: Find more about JS/TS SDKs at https://kontent.ai/learn/javascript
 // Using ES6 syntax
 import { ManagementClient } from '@kentico/kontent-management';
@@ -8,7 +8,8 @@ const client = new ManagementClient({
   apiKey: '<YOUR_API_KEY>'
 });
 
-const response = await client.listWorkflows()
+const response = await client.deleteWorkflow()
+  .byWorkflowId("f9f28df0-9dec-4ee3-b087-c501e4b75347")
+  //.byWorkflowCodename("my-workflow")
   .toPromise();
-const steps = response.data.find(workflow => workflow.codeName === 'default').steps;
 // EndDocSection

--- a/js/management-api-v2/GetWorkflows.js
+++ b/js/management-api-v2/GetWorkflows.js
@@ -1,4 +1,4 @@
-// DocSection: cm_api_v2_get_workflow_steps
+// DocSection: cm_api_v2_get_workflows
 // Tip: Find more about JS/TS SDKs at https://kontent.ai/learn/javascript
 // Using ES6 syntax
 import { ManagementClient } from '@kentico/kontent-management';
@@ -10,5 +10,4 @@ const client = new ManagementClient({
 
 const response = await client.listWorkflows()
   .toPromise();
-const steps = response.data.find(workflow => workflow.codeName === 'default').steps;
 // EndDocSection

--- a/js/management-api-v2/PostWorkflow.js
+++ b/js/management-api-v2/PostWorkflow.js
@@ -1,0 +1,66 @@
+// DocSection: cm_api_v2_post_workflow
+// Tip: Find more about JS/TS SDKs at https://kontent.ai/learn/javascript
+// Using ES6 syntax
+import { ManagementClient } from '@kentico/kontent-management';
+
+const client = new ManagementClient({
+  projectId: '<YOUR_PROJECT_ID>',
+  apiKey: '<YOUR_API_KEY>'
+});
+
+const response = await client.addWorkflow()
+  .withData(
+    {
+      name: "My workflow",
+      scopes: [
+        {
+          content_types: [
+            {
+              id: "1aeb9220-f167-4f8e-a7db-1bfec365fa80"
+            }
+          ]
+        }
+      ],
+      steps: [
+        {
+          name: "First step",
+          codename: "first_step",
+          color: "sky-blue",
+          transitions_to: [
+            {
+              step: {
+                codename: "second_step"
+              }
+            }
+          ],
+          role_ids: []
+        },
+        {
+          name: "Second step",
+          codename: "second_step",
+          color: "rose",
+          transitions_to: [
+            {
+              step: {
+                codename: "published"
+              }
+            }
+          ],
+          role_ids: [
+            "e796887c-38a1-4ab2-a999-c40861bb7a4b"
+          ]
+        }
+      ],
+      published_step: {
+        unpublish_role_ids: [
+          "e796887c-38a1-4ab2-a999-c40861bb7a4b"
+        ],
+        create_new_version_role_ids: []
+      },
+      archived_step: {
+        role_ids: []
+      }
+    }
+  )
+  .toPromise();
+// EndDocSection

--- a/js/management-api-v2/PutWorkflow.js
+++ b/js/management-api-v2/PutWorkflow.js
@@ -1,0 +1,76 @@
+// DocSection: cm_api_v2_put_workflow
+// Tip: Find more about JS/TS SDKs at https://kontent.ai/learn/javascript
+// Using ES6 syntax
+import { ManagementClient } from '@kentico/kontent-management';
+
+const client = new ManagementClient({
+  projectId: '<YOUR_PROJECT_ID>',
+  apiKey: '<YOUR_API_KEY>'
+});
+
+const response = await client.updateWorkflow()
+  .byWorkflowId("f9f28df0-9dec-4ee3-b087-c501e4b75347")
+  //.byWorkflowCodename("my-workflow")
+  .withData(
+    {
+      name: "My workflow",
+      scopes: [
+        {
+          content_types: [
+            {
+              codename: "Article"
+            }
+          ]
+        }
+      ],
+      steps: [
+        {
+          name: "First step",
+          codename: "first_step",
+          color: "sky-blue",
+          transitions_to: [
+            {
+              step: {
+                id: "16221cc2-bd22-4414-a513-f3e555c0fc93"
+              }
+            },
+            {
+              step: {
+                codename: "archived"
+              }
+            }
+          ],
+          role_ids: [
+            "e796887c-38a1-4ab2-a999-c40861bb7a4b"
+          ]
+        },
+        {
+          name: "Renamed Second step",
+          codename: "second_step_renamed",
+          color: "rose",
+          id: "16221cc2-bd22-4414-a513-f3e555c0fc93",
+          transitions_to: [
+            {
+              step: {
+                codename: "published"
+              }
+            }
+          ],
+          role_ids: []
+        }
+      ],
+      published_step: {
+        unpublish_role_ids: [],
+        create_new_version_role_ids: [
+            "e796887c-38a1-4ab2-a999-c40861bb7a4b"
+        ]
+      },
+      archived_step: {
+        role_ids: [
+            "e796887c-38a1-4ab2-a999-c40861bb7a4b"
+        ]
+      }
+    }
+  )
+  .toPromise();
+// EndDocSection

--- a/net/management-api-v2/DeleteWorkflow.cs
+++ b/net/management-api-v2/DeleteWorkflow.cs
@@ -1,0 +1,15 @@
+// DocSection: cm_api_v2_delete_workflow
+// Tip: Find more about .NET SDKs at https://kontent.ai/learn/net
+using Kentico.Kontent.Management;
+
+var client = new ManagementClient(new ManagementOptions
+{
+    ApiKey = "<YOUR_API_KEY>",
+    ProjectId = "<YOUR_PROJECT_ID>"
+});
+
+var identifier = Reference.ById(Guid.Parse("f9f28df0-9dec-4ee3-b087-c501e4b75347"));
+// var identifier = Reference.ByCodename("my_workflow");
+
+await client.DeleteWorkflowAsync(identifier);
+// EndDocSection

--- a/net/management-api-v2/GetWorkflows.cs
+++ b/net/management-api-v2/GetWorkflows.cs
@@ -1,0 +1,12 @@
+// DocSection: cm_api_v2_get_workflows
+// Tip: Find more about .NET SDKs at https://kontent.ai/learn/net
+using Kentico.Kontent.Management;
+
+var client = new ManagementClient(new ManagementOptions
+{
+    ApiKey = "<YOUR_API_KEY>",
+    ProjectId = "<YOUR_PROJECT_ID>"
+});
+
+var response = await client.ListWorkflowsAsync();
+// EndDocSection

--- a/net/management-api-v2/PostWorkflow.cs
+++ b/net/management-api-v2/PostWorkflow.cs
@@ -1,0 +1,61 @@
+// DocSection: cm_api_v2_post_workflow
+// Tip: Find more about .NET SDKs at https://kontent.ai/learn/net
+using Kentico.Kontent.Management;
+
+var client = new ManagementClient(new ManagementOptions
+{
+    ApiKey = "<YOUR_API_KEY>",
+    ProjectId = "<YOUR_PROJECT_ID>"
+});
+
+var secondStep = new WorkflowStepUpsertModel {
+    Name = "Second step",
+    CodeName = "second_step",
+    Color = WorkflowStepColorModel.Rose,
+    TransitionsTo = new [] {
+        new WorkflowStepTransitionToUpsertModel {
+            Step = Reference.ByCodename("published")
+        },
+    },
+    RoleIds = new [] { Guid.Parse("e796887c-38a1-4ab2-a999-c40861bb7a4b") }
+};
+
+var firstStep = new WorkflowStepUpsertModel {
+    Name = "First step",
+    CodeName = "first_step",
+    Color = WorkflowStepColorModel.SkyBlue,
+    TransitionsTo = new [] {
+        new WorkflowStepTransitionToUpsertModel {
+            Step = Reference.ByCodename(secondStep.CodeName),
+        }
+    },
+    RoleIds = Array.Empty<Guid>()
+};
+
+var newWorkflow = new WorkflowUpsertModel
+{
+    Name = "My workflow",
+    CodeName = "my_workflow",
+    Scopes = new [] {
+        new WorkflowScopeUpsertModel {
+            ContentTypes = new [] {
+                Reference.ById(Guid.Parse("1aeb9220-f167-4f8e-a7db-1bfec365fa80")),
+                Reference.ByCodename("Article")
+            }
+        }
+    },
+    Steps = new [] {
+        firstStep,
+        secondStep,
+    },
+    PublishedStep = new WorkflowPublishedStepUpsertModel {
+        RolesUnpublishArchivedCancelSchedulingIds = new [] { Guid.Parse("e796887c-38a1-4ab2-a999-c40861bb7a4b") },
+        RoleCreateNewVersionIds = Array.Empty<Guid>()
+    },
+    ArchivedStep = new WorkflowArchivedStepUpsertModel {
+        RoleIds = Array.Empty<Guid>()
+    }
+};
+
+var response = await client.CreateWorkflowAsync(newWorkflow);
+// EndDocSection

--- a/net/management-api-v2/PutWorkflow.cs
+++ b/net/management-api-v2/PutWorkflow.cs
@@ -1,0 +1,65 @@
+// DocSection: cm_api_v2_put_workflow
+// Tip: Find more about .NET SDKs at https://kontent.ai/learn/net
+using Kentico.Kontent.Management;
+
+var client = new ManagementClient(new ManagementOptions
+{
+    ApiKey = "<YOUR_API_KEY>",
+    ProjectId = "<YOUR_PROJECT_ID>"
+});
+
+var secondStep = new WorkflowStepUpsertModel {
+    Name = "Renamed Second step",
+    CodeName = "second_step_renamed",
+    Color = WorkflowStepColorModel.Rose,
+    Id = Guid.Parse("16221cc2-bd22-4414-a513-f3e555c0fc93"),
+    TransitionsTo = new [] {
+        new WorkflowStepTransitionToUpsertModel {
+            Step = Reference.ByCodename("published")
+        },
+    },
+    RoleIds = Array.Empty<Guid>(),
+};
+
+var firstStep = new WorkflowStepUpsertModel {
+    Name = "First step",
+    CodeName = "first_step",
+    Color = WorkflowStepColorModel.SkyBlue,
+    TransitionsTo = new [] {
+        new WorkflowStepTransitionToUpsertModel {
+            Step = Reference.ById(secondStep.Id.Value),
+        },
+        new WorkflowStepTransitionToUpsertModel {
+            Step = Reference.ByCodename("archived"),
+        }
+    },
+    RoleIds = new [] { Guid.Parse("e796887c-38a1-4ab2-a999-c40861bb7a4b") }
+};
+
+var updatedWorkflow = new WorkflowUpsertModel
+{
+    Name = "My updated workflow",
+    CodeName = "my_updated_workflow",
+    Scopes = new [] {
+        new WorkflowScopeUpsertModel {
+            ContentTypes = new [] { Reference.ByCodename("Article") }
+        }
+    },
+    Steps = new [] {
+        firstStep,
+        secondStep,
+    },
+    PublishedStep = new WorkflowPublishedStepUpsertModel {
+        RolesUnpublishArchivedCancelSchedulingIds = Array.Empty<Guid>(),
+        RoleCreateNewVersionIds = Array.Empty<Guid>()
+    },
+    ArchivedStep = new WorkflowArchivedStepUpsertModel {
+        RoleIds =  new [] { Guid.Parse("e796887c-38a1-4ab2-a999-c40861bb7a4b") }
+    }
+};
+
+var identifier = Reference.ByCodename("my_workflow");
+// var identifier = Reference.ById(Guid.Parse("f9f28df0-9dec-4ee3-b087-c501e4b75347"));
+
+var response = await client.UpdateWorkflowAsync(identifier, updatedWorkflow);
+// EndDocSection

--- a/rest/management-api-v2/PutWorkflow.curl
+++ b/rest/management-api-v2/PutWorkflow.curl
@@ -10,7 +10,7 @@ curl --request PUT \
     {
       "content_types": [
         {
-          "id": "1aeb9220-f167-4f8e-a7db-1bfec365fa80"
+          "codename": "Article"
         }
       ]
     }
@@ -19,21 +19,28 @@ curl --request PUT \
     {
       "name": "First step",
       "codename": "first_step",
-      "id": "16221cc2-bd22-4414-a513-f3e555c0fc93",
       "color": "sky-blue",
       "transitions_to": [
         {
           "step": {
-            "codename": "second_step"
+            "id": "16221cc2-bd22-4414-a513-f3e555c0fc93"
+          }
+        },
+        {
+          "step": {
+            "codename": "archived"
           }
         }
       ],
-      "role_ids": []
+      "role_ids": [
+        "e796887c-38a1-4ab2-a999-c40861bb7a4b"
+      ]
     },
     {
-      "name": "Second step",
-      "codename": "second_step",
+      "name": "Renamed Second step",
+      "codename": "second_step_renamed",
       "color": "rose",
+      "id": "16221cc2-bd22-4414-a513-f3e555c0fc93",
       "transitions_to": [
         {
           "step": {
@@ -41,19 +48,19 @@ curl --request PUT \
           }
         }
       ],
-      "role_ids": [
-        "e796887c-38a1-4ab2-a999-c40861bb7a4b"
-      ]
+      "role_ids": []
     }
   ],
   "published_step": {
-    "unpublish_role_ids": [
-      "e796887c-38a1-4ab2-a999-c40861bb7a4b"
-    ],
-    "create_new_version_role_ids": []
+    "unpublish_role_ids": [],
+    "create_new_version_role_ids": [
+        "e796887c-38a1-4ab2-a999-c40861bb7a4b"
+    ]
   },
   "archived_step": {
-    "role_ids": []
+    "role_ids": [
+        "e796887c-38a1-4ab2-a999-c40861bb7a4b"
+    ]
   }
 }'
 # EndDocSection


### PR DESCRIPTION
### Motivation

This is a follow-up to the https://github.com/KenticoDocs/kontent-docs-samples/pull/51 that adds a sample for yet nonexistent JS API method that would call the new Update workflow end-point.

### Context

Add the following information:

* When do you need the code to go public? Once the https://github.com/Kentico/kontent-management-sdk-js/issues/78 is resolved and a new version of JS SDK is released.
* Is the pull request complete and ready for review? No
  * setting this PR to Draft until 
     1. https://github.com/Kentico/kontent-management-sdk-js/issues/78 is released (since contract of SDK might change)
     2. https://github.com/KenticoDocs/kontent-docs-samples/pull/51 is merged (since this branch is based on the other)
