### PR TITLE
KCL-8976 Extend schedule publish with REST code sample

### DIFF
--- a/rest/management-api-v2/PutVariantPublishOrSchedule.curl
+++ b/rest/management-api-v2/PutVariantPublishOrSchedule.curl
@@ -10,6 +10,7 @@ curl --request PUT \
   --header 'Content-type: application/json' \
   --data '
 {
-  "scheduled_to": "2038-01-19T04:14:08+01:00"
+  "scheduled_to": "2038-01-19T04:14:08+01:00",
+  "display_timezone": "Europe/Prague"
 }'
 # EndDocSection


### PR DESCRIPTION
### Motivation

Based on this task https://kentico.atlassian.net/browse/KCL-8976?atlOrigin=eyJpIjoiZTNjZDQyNTM5N2U1NGFhNmE0MmI4OTUwYTI0NjBmZDAiLCJwIjoiaiJ9

As a part timezone iteration, we want to extend schedule publish endpoint with new optional property display_timezone which will modify how scheduled publish date and time will be displayed in Kontent app.

### Context

Add the following information:

* When do you need the code to go public? Provide a release date and/or explanation.
22.6. 2022
* Is the pull request complete and ready for review? 
Yes

