### PR TITLE
KCL-8976 - Extend REST code sample for schedule unpublish

### DIFF
--- a/rest/management-api-v2/PutVariantUnpublishAndArchive.curl
+++ b/rest/management-api-v2/PutVariantUnpublishAndArchive.curl
@@ -6,6 +6,7 @@ curl --request PUT \
   --header 'Authorization: Bearer <YOUR_API_KEY>' \
   --header 'Content-type: application/json' \
   --data '{
-  "scheduled_to": "2038-01-19T04:14:08+01:00"
+  "scheduled_to": "2038-01-19T04:14:08+01:00",
+  "display_timezone": "Europe/Prague"
 }'
 # EndDocSection


### PR DESCRIPTION
### Motivation

Based on this task https://kentico.atlassian.net/browse/KCL-8987?atlOrigin=eyJpIjoiYWJlNDhjMjYwMmEwNGQ5YzlmMTg3ZTQ1ZGVkNmZiNjQiLCJwIjoiaiJ9

As a part timezone iteration, we want to extend schedule unpublish endpoint with new optional property display_timezone which will modify how scheduled unpublish date and time will be displayed in Kontent app.

### Context

Add the following information:

* When do you need the code to go public? Provide a release date and/or explanation.
22.6. 2022
* Is the pull request complete and ready for review? 
Yes

