### PR TITLE
Extend creation of content type with a sample of default value for the Text element

### DIFF
--- a/net/import-content-model/CreateType.cs
+++ b/net/import-content-model/CreateType.cs
@@ -35,7 +35,14 @@ var response = await client.CreateContentTypeAsync(new ContentTypeCreateModel
         new TextElementMetadataModel
         {
             Name = "Title",
-            ContentGroup = Reference.ByExternalId("content")
+            ContentGroup = Reference.ByExternalId("content"),
+            DefaultValue = new TextElementDefaultValueModel
+            {
+                Global = new TypeValue<string>()
+                {
+                    Value = "This is the default value of the text element."
+                }
+            }
         },
         new AssetElementMetadataModel
         {

--- a/net/management-api-v2/PostType.cs
+++ b/net/management-api-v2/PostType.cs
@@ -33,6 +33,13 @@ var response = await client.CreateContentTypeAsync(new ContentTypeCreateModel
             Name = "Article title",
             Codename = "title",
             ContentGroup = Reference.ByCodename("article-copy"),
+            DefaultValue = new TextElementDefaultValueModel
+            {
+                Global = new TypeValue<string>()
+                {
+                    Value = "This is the default value of the text element."
+                }
+            }
         },
         new RichTextElementMetadataModel
         {

--- a/rest/management-api-v2/PostType.curl
+++ b/rest/management-api-v2/PostType.curl
@@ -25,6 +25,11 @@ curl --request POST \
      "type": "text",
      "content_group": {
        "external_id": "article-copy"
+     },
+     "default": {
+       "global": {
+         "value": "This is the default value of the text element."
+       }
      }
    },
    {


### PR DESCRIPTION
Extend creation of content type with a sample of default value for the Text element

### Motivation

We are adding the new API for the defining elements' default values

JIRA - https://kentico.atlassian.net/browse/KCL-8857, 
related GitHub PR of the .NET SDK - https://github.com/Kentico/kontent-management-sdk-net/pull/182

### Context

Add the following information:

* When do you need the code to go public? Provide a release date and/or explanation.
** Please keep in mind that REST examples can be released anytime, but for the .NET we need to wait to its release
